### PR TITLE
添加千分位分隔符

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,8 +69,11 @@
         if (cost < 5000000) {
             cost = 5000000;
         }
-        document.getElementById("cost").value = cost;
-
+        document.getElementById("cost").value = format(cost);
+    }
+    
+    function format(num) {
+        return (num.toString().indexOf('.') !== -1) ? num.toLocaleString() : num.toString().replace(/(\d)(?=(?:\d{3})+$)/g, '$1,');
     }
 </script>
 <label for="start">


### PR DESCRIPTION
原本的格式可以使用，但不容易让人在网页上直观判断具体要花多少钱。

这一改动将能在保证能够复制粘贴到合同价格栏当中的同时，保证了数值本身的可读性。

兼容小数。